### PR TITLE
Implement Int64 type in rbx-binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Roblox Lua implementation of DOM APIs, allowing Instance reflection from inside 
 | Float32            | `Players.RespawnTime`           | ✔ | ✔ | ✔ | ✔ |
 | Float64            | `Sound.PlaybackLoudness`        | ✔ | ✔ | ✔ | ✔ |
 | Int32              | `Frame.ZIndex`                  | ✔ | ✔ | ✔ | ✔ |
-| Int64              | `Player.UserId`                 | ✔ | ✔ | ✔ | ❌ |
+| Int64              | `Player.UserId`                 | ✔ | ✔ | ✔ | ✔ |
 | NumberRange        | `ParticleEmitter.Lifetime`      | ✔ | ✔ | ✔ | ❌ |
 | NumberSequence     | `Beam.Transparency`             | ✔ | ✔ | ✔ | ❌ |
 | PhysicalProperties | `Part.CustomPhysicalProperties` | ✔ | ✔ | ✔ | ❌ |

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -447,7 +447,31 @@ impl<R: Read> BinaryDeserializer<R> {
             Type::Rect => {}
             Type::PhysicalProperties => {}
             Type::Color3uint8 => {}
-            Type::Int64 => {}
+            Type::Int64 => match canonical_type {
+                VariantType::Int64 => {
+                    let mut values = vec![0; type_info.referents.len()];
+                    chunk.read_interleaved_i64_array(&mut values)?;
+
+                    for i in 0..values.len() {
+                        let instance = self
+                            .instances_by_ref
+                            .get_mut(&type_info.referents[i])
+                            .unwrap();
+                        let rbx_value = Variant::Int64(values[i]);
+                        instance
+                            .properties
+                            .push((canonical_name.clone(), rbx_value));
+                    }
+                }
+                invalid_type => {
+                    return Err(InnerError::PropTypeMismatch {
+                        type_name: type_info.type_name.clone(),
+                        prop_name,
+                        valid_type_names: "Int64",
+                        actual_type_name: format!("{:?}", invalid_type),
+                    });
+                }
+            },
         }
 
         Ok(())

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -533,6 +533,19 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
                             }
                         }
                     }
+                    Type::Int64 => {
+                        let mut buf = Vec::with_capacity(values.len());
+
+                        for (i, rbx_value) in values {
+                            if let Variant::Int64(value) = rbx_value.as_ref() {
+                                buf.push(*value);
+                            } else {
+                                return type_mismatch(i, &rbx_value, "Int64");
+                            }
+                        }
+
+                        chunk.write_interleaved_i64_array(buf.into_iter())?;
+                    }
                     _ => {
                         return Err(InnerError::UnsupportedPropType {
                             type_name: type_name.clone(),
@@ -630,6 +643,7 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
             VariantType::Int32 => Variant::Int32(0),
             VariantType::Float32 => Variant::Float32(0 as f32),
             VariantType::Float64 => Variant::Float64(0 as f64),
+            VariantType::Int64 => Variant::Int64(0),
             _ => return None,
         })
     }

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -643,7 +643,7 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
             VariantType::Int32 => Variant::Int32(0),
             VariantType::Float32 => Variant::Float32(0 as f32),
             VariantType::Float64 => Variant::Float64(0 as f64),
-            VariantType::Int64 => Variant::Int64(0),
+            VariantType::Int64 => Variant::Int64(0 as i64),
             _ => return None,
         })
     }

--- a/rbx_binary/src/tests/models.rs
+++ b/rbx_binary/src/tests/models.rs
@@ -30,4 +30,5 @@ binary_tests! {
     three_screengui,
     bloomeffect,
     funny_numbervalue,
+    three_intvalues,
 }

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-intvalues__decoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-intvalues__decoded.snap
@@ -1,0 +1,46 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: decoded_viewed
+---
+- referent: referent-0
+  name: Value=1234567
+  class: IntValue
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    Tags:
+      Type: BinaryString
+      Value: ""
+    Value:
+      Type: Int64
+      Value: 1234567
+  children: []
+- referent: referent-1
+  name: Value=1337
+  class: IntValue
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    Tags:
+      Type: BinaryString
+      Value: ""
+    Value:
+      Type: Int64
+      Value: 1337
+  children: []
+- referent: referent-2
+  name: Value=-7654321
+  class: IntValue
+  properties:
+    AttributesSerialize:
+      Type: BinaryString
+      Value: ""
+    Tags:
+      Type: BinaryString
+      Value: ""
+    Value:
+      Type: Int64
+      Value: -7654321
+  children: []

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-intvalues__encoded.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-intvalues__encoded.snap
@@ -1,0 +1,57 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_roundtrip
+---
+num_types: 1
+num_instances: 3
+chunks:
+  - Inst:
+      type_id: 0
+      type_name: IntValue
+      object_format: 0
+      referents:
+        - 0
+        - 1
+        - 2
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Value=1234567
+        - Value=1337
+        - Value=-7654321
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Value
+      prop_type: Int64
+      values:
+        - 1234567
+        - 1337
+        - -7654321
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+        - - 2
+          - -1
+  - End

--- a/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-intvalues__input.snap
+++ b/rbx_binary/src/tests/snapshots/rbx_binary__tests__util__three-intvalues__input.snap
@@ -1,0 +1,61 @@
+---
+source: rbx_binary/src/tests/util.rs
+expression: text_decoded
+---
+num_types: 1
+num_instances: 3
+chunks:
+  - Meta:
+      entries:
+        - - ExplicitAutoJoints
+          - "true"
+  - Inst:
+      type_id: 0
+      type_name: IntValue
+      object_format: 0
+      referents:
+        - 0
+        - 1
+        - 2
+  - Prop:
+      type_id: 0
+      prop_name: AttributesSerialize
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Name
+      prop_type: String
+      values:
+        - Value=1234567
+        - Value=1337
+        - Value=-7654321
+  - Prop:
+      type_id: 0
+      prop_name: Tags
+      prop_type: String
+      values:
+        - ""
+        - ""
+        - ""
+  - Prop:
+      type_id: 0
+      prop_name: Value
+      prop_type: Int64
+      values:
+        - 1234567
+        - 1337
+        - -7654321
+  - Prnt:
+      version: 0
+      links:
+        - - 0
+          - -1
+        - - 1
+          - -1
+        - - 2
+          - -1
+  - End

--- a/rbx_binary/src/text_deserializer.rs
+++ b/rbx_binary/src/text_deserializer.rs
@@ -172,6 +172,7 @@ pub enum DecodedValues {
     Int32(Vec<i32>),
     Float32(Vec<f32>),
     Float64(Vec<f64>),
+    Int64(Vec<i64>),
 }
 
 impl DecodedValues {
@@ -217,6 +218,13 @@ impl DecodedValues {
                 }
 
                 Some(DecodedValues::Float64(values))
+            }
+            Type::Int64 => {
+                let mut values = vec![0; prop_count];
+
+                reader.read_interleaved_i64_array(&mut values).unwrap();
+
+                Some(DecodedValues::Int64(values))
             }
             _ => None,
         }


### PR DESCRIPTION
Wasn't sure where to put `read_interleaved_i64_array` or `write_interleaved_i64_array`, so I just added them after `read_referent_array` and `write_referents` since Int64 comes after Referent in terms of data types. Let me know if you think they should be near their i32 variants instead.