### PR TITLE
rbx_binary Fix clippy warnings

### DIFF
--- a/rbx_binary/src/core.rs
+++ b/rbx_binary/src/core.rs
@@ -78,9 +78,9 @@ pub trait RbxReadExt: Read {
 
         let mut last = 0;
 
-        for i in 0..output.len() {
-            output[i] += last;
-            last = output[i];
+        for referent in output.iter_mut() {
+            *referent += last;
+            last = *referent;
         }
 
         Ok(())

--- a/rbx_binary/src/deserializer.rs
+++ b/rbx_binary/src/deserializer.rs
@@ -363,12 +363,12 @@ impl<R: Read> BinaryDeserializer<R> {
                     let mut values = vec![0; type_info.referents.len()];
                     chunk.read_interleaved_i32_array(&mut values)?;
 
-                    for i in 0..values.len() {
+                    for (i, value) in values.into_iter().enumerate() {
                         let instance = self
                             .instances_by_ref
                             .get_mut(&type_info.referents[i])
                             .unwrap();
-                        let rbx_value = Variant::Int32(values[i]);
+                        let rbx_value = Variant::Int32(value);
                         instance
                             .properties
                             .push((canonical_name.clone(), rbx_value));
@@ -388,12 +388,12 @@ impl<R: Read> BinaryDeserializer<R> {
                     let mut values = vec![0.0; type_info.referents.len()];
                     chunk.read_interleaved_f32_array(&mut values)?;
 
-                    for i in 0..values.len() {
+                    for (i, value) in values.into_iter().enumerate() {
                         let instance = self
                             .instances_by_ref
                             .get_mut(&type_info.referents[i])
                             .unwrap();
-                        let rbx_value = Variant::Float32(values[i]);
+                        let rbx_value = Variant::Float32(value);
                         instance
                             .properties
                             .push((canonical_name.clone(), rbx_value));
@@ -550,12 +550,12 @@ impl<R: Read> BinaryDeserializer<R> {
                     let mut values = vec![0; type_info.referents.len()];
                     chunk.read_interleaved_i64_array(&mut values)?;
 
-                    for i in 0..values.len() {
+                    for (i, value) in values.into_iter().enumerate() {
                         let instance = self
                             .instances_by_ref
                             .get_mut(&type_info.referents[i])
                             .unwrap();
-                        let rbx_value = Variant::Int64(values[i]);
+                        let rbx_value = Variant::Int64(value);
                         instance
                             .properties
                             .push((canonical_name.clone(), rbx_value));
@@ -682,14 +682,14 @@ impl FileHeader {
         let mut magic_header = [0; 8];
         source.read_exact(&mut magic_header)?;
 
-        if &magic_header != FILE_MAGIC_HEADER {
+        if magic_header != FILE_MAGIC_HEADER {
             return Err(InnerError::BadHeader);
         }
 
         let mut signature = [0; 6];
         source.read_exact(&mut signature)?;
 
-        if &signature != FILE_SIGNATURE {
+        if signature != FILE_SIGNATURE {
             return Err(InnerError::BadHeader);
         }
 

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::{Borrow, Cow},
     collections::{BTreeMap, HashMap, VecDeque},
+    convert::TryInto,
     io::{self, Write},
     u32,
 };
@@ -320,11 +321,8 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
     fn generate_referents(&mut self) {
         self.id_to_referent.reserve(self.relevant_instances.len());
 
-        let mut next_referent = 0;
-
-        for id in &self.relevant_instances {
-            self.id_to_referent.insert(*id, next_referent);
-            next_referent += 1;
+        for (next_referent, id) in self.relevant_instances.iter().enumerate() {
+            self.id_to_referent.insert(*id, next_referent.try_into().unwrap());
         }
     }
 
@@ -445,7 +443,7 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
                                 .properties
                                 .get(prop_name)
                                 .map(Cow::Borrowed)
-                                .unwrap_or(Cow::Borrowed(prop_info.default_value.borrow()))
+                                .unwrap_or_else(|| Cow::Borrowed(prop_info.default_value.borrow()))
                         }
                     })
                     .enumerate();

--- a/rbx_binary/src/serializer.rs
+++ b/rbx_binary/src/serializer.rs
@@ -322,7 +322,8 @@ impl<'a, W: Write> BinarySerializer<'a, W> {
         self.id_to_referent.reserve(self.relevant_instances.len());
 
         for (next_referent, id) in self.relevant_instances.iter().enumerate() {
-            self.id_to_referent.insert(*id, next_referent.try_into().unwrap());
+            self.id_to_referent
+                .insert(*id, next_referent.try_into().unwrap());
         }
     }
 


### PR DESCRIPTION
Nothing too crazy here - this commit converts several loops that were over ranges to loops over iterators, removes a couple unnecessary references, and changes an `unwrap_or`  to an `unwrap_or_else`. Clippy is happy 😃 